### PR TITLE
make MMWRweekday() locale-independent (fixes #1)

### DIFF
--- a/R/MMWRweekday.R
+++ b/R/MMWRweekday.R
@@ -3,14 +3,15 @@
 #' This function returns the weekday of a given date according to MMWR.
 #' 
 #' @param date vector which can be coerced to class \code{Date}
-#' @return vector of weekdays as a factor
-#' @author Jarad Niemi \email{niemi@@iastate.edu}
+#' @return vector of weekdays as a factor (first level is Sunday)
+#' @author Sebastian Meyer \email{seb.meyer@@fau.de}
 #' @seealso \code{\link{MMWRweek}}
 #' @export
 #' @examples
 #' y <- as.Date(paste(1999:2011, "-12-31", sep = ""))
 #' data.frame(date = format(y), MMWRweekday = MMWRweekday(y))
 MMWRweekday = function(date) {
-  return(factor(weekdays(as.Date(date)), 
-                levels=c('Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday')))
+    factor(strftime(as.Date(date), "%w"), # Sunday is 0
+           levels = 0:6,
+           labels = c('Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'))
 }

--- a/inst/tests/test-MMWRweekday.R
+++ b/inst/tests/test-MMWRweekday.R
@@ -3,7 +3,11 @@ context('MMWRweekday')
 days = c('Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday')
 
 dates = seq(as.Date('1900-01-01'), as.Date('2015-12-31'), by='day')
+
+oldlocale <- Sys.getlocale("LC_TIME")
+Sys.setlocale("LC_TIME", "C")
 truth = factor(weekdays(dates), levels=days)
+Sys.setlocale("LC_TIME", oldlocale)
 
 test_that('MMWRweekday returns a factor vector', {
   wday = MMWRweekday(dates)
@@ -17,4 +21,4 @@ test_that('MMWRweekday returns correct values', {
   expect_that(MMWRweekday(dates    ), equals(truth))
   expect_that(MMWRweekday(dates_chr), equals(truth))
 })
- 
+


### PR DESCRIPTION
Previously, MMWRweekday() would return missing values in non-English locales